### PR TITLE
管理者側レイアウト変更

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -9,6 +9,12 @@ class Admin::ItemsController < ApplicationController
   end
 
   def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to admin_item_path(params[:id])
+    else
+      render :edit
+    end
   end
 
   def create

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -6,6 +6,6 @@ class Public::ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-  
-  
+
+
 end

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -9,21 +9,22 @@
   <% end %>
 <% end %>
 
-
-<h2 class="lead"><%= "#{@customer.last_name}" "#{@customer.first_name}" %>さんの会員情報</h2>
 <%= form_with  model:@customer,url: admin_customer_path,method: :put, local:true do |f| %>
-   <div class='form-group'>
-    <span>id:</span>
-    <span><%= @customer.id %></span>
+
+　<div class="form-group row">
+　  <legend class="col-sm-2 col-form-label">会員ID</legend>
+    <div class="col-sm-3">
+      <legend class="form-control-plaintext"><%= @customer.id %></legend>
+    </div>
   </div>
 
   <div class='form-group'>
     <div class="row">
-      <%= f.label :first_name, '名前（名）',class:"col-sm-2 col-form-label" %>
-      <div class="col">
+      <legend class="col-form-label col-sm-2">氏名</legend>
+      <div class="col-sm-3">
         <%= f.text_field :last_name, placeholder:"名前（姓）",class:'form-control'%>
       </div>
-      <div class="col">
+      <div class="col-sm-3">
         <%= f.text_field :first_name, placeholder:"名前（名）",class:'form-control'%>
       </div>
     </div>
@@ -31,11 +32,11 @@
 
   <div class='form-group'>
     <div class="row">
-      <%= f.label :first_name, '名前（カナ）',class:"col-sm-2 col-form-label" %>
-      <div class="col">
+      <legend class="col-form-label col-sm-2">フリガナ</legend>
+      <div class="col-sm-3">
         <%= f.text_field :last_name_kana, placeholder:"名前（カナ姓）",class:'form-control'%>
       </div>
-      <div class="col">
+      <div class="col-sm-3">
           <%= f.text_field :first_name_kana, placeholder:"名前（カナ名）" ,class:'form-control'%>
       </div>
     </div>
@@ -43,22 +44,22 @@
 
   <div class="form-group row">
     <%= f.label :postal_code, '郵便番号',class:"col-sm-2 col-form-label"%>
-    <div class="col-sm-5">
+    <div class="col-sm-3">
       <%= f.text_field :postal_code, placeholder:"郵便番号" ,class:'form-control'%>
     </div>
   </div>
 
-  <div class='form-group row'>
-    <%= f.label :address, '住所', class:"col-sm-2 col-form-label"%>
-    <div class="col-sm-10">
-    　<%= f.text_field :address, placeholder:"住所", class:'form-control' %>
+  <div class="form-group row">
+    <%= f.label :address, '住所',class:"col-sm-2 col-form-label"%>
+    <div class="col-sm-8">
+      <%= f.text_field :address, placeholder:"住所" ,class:'form-control'%>
     </div>
   </div>
 
-  <div class='form-group row'>
-    <%= f.label :telephone_number, '電話番号',class:"col-sm-2 col-form-label" %>
-    <div class="col-sm-5">
-    　<%= f.text_field :telephone_number, placeholder:"電話番号",class:'form-control'%>
+　<div class="form-group row">
+    <%= f.label :telephone_number, '電話番号',class:"col-sm-2 col-form-label"%>
+    <div class="col-sm-3">
+      <%= f.text_field :telephone_number, placeholder:"電話番号" ,class:'form-control'%>
     </div>
   </div>
 
@@ -76,7 +77,6 @@
     </div>
   </fieldset>
 
-
-  <%= f.submit "変更を保存", class:"btn btn-success mt-3 mb-3" %>
+  <%= f.submit "変更を保存", class:"btn btn-success mt-3 mb-3 offset-sm-2" %>
 <% end %>
 </div>

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,67 +1,34 @@
 <div class="container">
- <h5 class= "toptext text-center">All Customers</h5>
- <div class="row">
-    <!--<ul class="customers">-->
-        <table class="table">
-          <thead class="bg-light">
-            <tr>
-              <th>会員ID</th>
-              <th>⽒名</th>
-              <th>メールアドレス</th>
-              <th>ステータス</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-          <% @customers.each do |customer| %>
-            <tr>
-              <td><%= customer.id %></td>
-              <td><%= customer.last_name %> <%= customer.first_name %></td>
-              <td><%= customer.email %></td>
-              <td>
-                <% if customer.is_deleted %>
-                <span>退会</span>
-                <% else %>
-                <span>有効</span>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to '編集', edit_admin_customer_path(customer.id),{class:'btn btn-danger'} %>
-              </td>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
+  <h5 class= "toptext text-center">会員一覧</h5>
+  <div class="row">
+    <table class="table">
+      <thead class="bg-light">
+        <tr>
+          <th>会員ID</th>
+          <th>⽒名</th>
+          <th>メールアドレス</th>
+          <th>ステータス</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% @customers.each do |customer| %>
+        <tr>
+          <td><%= customer.id %></td>
+
+          <td><%= link_to "#{customer.last_name + customer.first_name}", admin_customer_path(customer.id),class:"text-dark" %></td>
+          <td><%= customer.email %></td>
+          <td>
+            <% if customer.is_deleted %>
+            <span class="text-muted">退会</span>
+            <% else %>
+            <span class="text-success">有効</span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
   </div>
 </div>
-<table class="table table-bordered w-75">
-  <thead class="thead-light">
-    <tr>
-      <th>会員ID</th>
-      <th>⽒名</th>
-      <th>メールアドレス</th>
-      <th>ステータス</th>
-      <th></th>
-    </tr>
-  </thead>
-  <% @customers.each do |customer| %>
-    <tr>
-      <td><%= customer.id %></td>
-      <td><%= customer.last_name %> <%= customer.first_name %></td>
-      <td><%= customer.email %></td>
-      <td>
-        <% if customer.is_deleted %>
-        <span>退会</span>
-        <% else %>
-        <span>有効</span>
-        <% end %>
-      </td>
-      <td>
-        <%= link_to '編集', edit_admin_customer_path(customer.id),{class:'btn btn-danger'} %>
-      </td>
-    </tr>
-  <% end %>
-  </tr>
-</table>
-
 <%= paginate @customers %>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,47 +1,47 @@
-<h5 class= "toptext text-center"><%= "#{@customer.last_name}" "#{@customer.first_name}" %>さんの会員詳細</h5>
-<!--leadクラスってなんか指定してありますか？-->
-
-
-<table class="table table-bordered w-75">
-  <tr>
-    <th>名前（姓）</th>
-    <td><%= @customer.last_name %></td>
-  </tr>
-  <tr>
-    <th>名前（名）</th>
-    <td><%= @customer.first_name %></td>
-  </tr>
-  <tr>
-    <th>名前（カナ姓）</th>
-    <td><%= @customer.last_name_kana %></td>
-  </tr>
-  <tr>
-    <th>名前（カナ名）</th>
-    <td><%= @customer.first_name_kana %></td>
-  </tr>
-  <tr>
-    <th>郵便番号</th>
-    <td><%= @customer.postal_code %></td>
-  </tr>
-  <tr>
-    <th>住所</th>
-    <td><%= @customer.address %></td>
-  </tr>
-  <tr>
-    <th>電話番号</th>
-    <td><%= @customer.telephone_number %></td>
-  </tr>
-
-  <tr>
-    <th>会員ステータス</th>
-    <td> 
-      <% if @customer.is_deleted %>
-      <span>退会</span>
-      <% else %>
-      <span>有効</span>
-      <% end %>
-    </td>
-  </tr>
-</table>
-
-<p><%= link_to '編集する', edit_admin_customer_path(@customer.id),{class:'btn btn-secondary'} %></p>
+<div class="container">
+  <h5 class= "toptext text-center"><%= "#{@customer.last_name}" "#{@customer.first_name}" %>さんの会員詳細</h5>
+  
+  <table class="table table-borderless">
+    <tr>
+      <th>会員ID</th>
+      <td><%= @customer.id %></td>
+    </tr>
+    <tr>
+      <th>氏名</th>
+      <td><%= @customer.last_name %>　　<%= @customer.last_name %></td>
+    </tr>
+    <tr>
+      <th>フリガナ</th>
+      <td><%= @customer.last_name_kana %>　　<%= @customer.first_name_kana %></td>
+    </tr>
+    <tr>
+      <th>郵便番号</th>
+      <td><%= @customer.postal_code %></td>
+    </tr>
+    <tr>
+      <th>住所</th>
+      <td><%= @customer.address %></td>
+    </tr>
+    <tr>
+      <th>電話番号</th>
+      <td><%= @customer.telephone_number %></td>
+    </tr>
+    <tr>
+      <th>メールアドレス</th>
+      <td><%= @customer.email %></td>
+    </tr>
+  
+    <tr>
+      <th>会員ステータス</th>
+      <td>
+        <% if @customer.is_deleted %>
+        <span class="text-muted">退会</span>
+        <% else %>
+        <span class="text-success">有効</span>
+        <% end %>
+      </td>
+    </tr>
+  </table>
+  
+  <p><%= link_to '編集する', edit_admin_customer_path(@customer.id),{class:'btn btn-success col-sm-1 offset-sm-3'} %></p>
+</div>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,38 +1,58 @@
+<div class="container">
 <h5 class= "toptext text-center">商品編集</h5>
-<%= form_with model: @item, url: admin_items_path, method: :post, local:true do |f| %>
 
-  <div class='input-block'>
-  　<%= f.label :image, '商品画像' %>
-    <%= f.attachment_field :image %>
-  </div>
+    <%= form_with model: @item, url: admin_items_path, method: :post, local:true do |f| %>
 
-  <div class='input-block'>
-  　<%= f.label :name, '商品名' %>
-    <%= f.text_field :name, class: "",placeholder: "商品名" %>
-  </div>
+      <div class="form-group row">
+        <%= f.label :image, '商品画像', class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6">
+          <%= f.attachment_field :image%>
+        </div>
+      </div>
 
-  <div class='input-block'>
-    <%= f.label :introduction, '商品説明' %>
-    <%= f.text_area :introduction, class: "",placeholder: "ここに説明文を記述します" %>
-  </div>
+      <div class="form-group row">
+        <%= f.label :name, '商品名', class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6">
+          <%= f.text_field :name, placeholder: "商品名", class: "form-control" %>
+        </div>
+      </div>
 
-  <div class='input-block'>
-    <%= f.label :genre, 'ジャンル' %>
-    <%= f.collection_select :genre_id, @genres, :id, :name, { prompt: "選択してください" } %>
-  </div>
+      <div class="form-group row">
+        <%= f.label :introduction, '商品説明', class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6" rows="3" >
+          <%= f.text_field :introduction, placeholder: "商品説明", class: "form-control"%>
+        </div>
+      </div>
 
-  <div class='input-block'>
-    <%= f.label :price, '税抜価格' %>
-    <%= f.text_field :price, class: "",placeholder: "1000" %>
-  </div>
+      <div class="form-group row">
+        <%= f.label :genre, 'ジャンル', class: "col-sm-2 offset-sm-1 col-form-label" %>
+        <div class="col-sm-6">
+          <%= f.collection_select :genre_id, @genres, :id, :name, { prompt: "選択してください" }, class: "form-control" %>
+        </div>
+      </div>
 
-  <div class='input-block'>
-    <%= f.label :name, '販売ステータタス' %>
-  　<%= f.radio_button :sale_status, true %>
-    <%= f.label :sale_status, '販売中', value: true %>
-    <%= f.radio_button :sale_status, false %>
-    <%= f.label :sale_status, '販売停止中', value: f %>
-  </div>
+      <div class="form-group row">
+        <%= f.label :price, "税抜価格", class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6">
+          <%= f.text_field :price, placeholder: "税抜価格", class: "form-control" %> <span>円</span>
+        </div>
+      </div>
 
-  <%= f.submit '変更を保存', class: "btn btn-success" %>
-<% end %>
+      <fieldset class="form-group">
+    <div class="row">
+      <legend class="col-form-label col-sm-2 offset-sm-1 pt-0">販売ステータス</legend>
+      <div class="col-sm-6">
+        <div class="form-check form-check-inline">
+          <%= f.radio_button :sale_status, true, class:'form-check-input' %><label　class="form-check-label">販売中</label>
+        </div>
+        <div class="form-check form-check-inline">
+    　　　　  <%= f.radio_button :sale_status, false, class:'form-check-input' %><label　class="form-check-label">販売停止中</label>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+
+      <%= f.submit '新規登録', class: "btn btn-success col-xs-7 mx-auto d-block" %>
+    <% end %>
+
+</div>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,41 +1,59 @@
 <div class="container">
   <h5 class= "toptext text-center">新規情報登録</h5>
-  <div class="row justify-content-center">
+  <!--<div class="row justify-content-center">-->
     <%= form_with model: @item, url: admin_items_path, method: :post, local:true do |f| %>
-    <div class='input-block'>
-    　<%= f.label :image, '商品画像', class: "mx-sm-3"%>
-      <%= f.attachment_field :image%>
-    </div>
 
-    <div class='input-block'>
-    　<%= f.label :name, '商品名', class: "mx-sm-3" %>
-      <%= f.text_field :name, placeholder: "商品名", class: "col-sm-8" %>
-    </div>
+      <div class="form-group row">
+        <%= f.label :image, '商品画像', class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6">
+          <%= f.attachment_field :image%>
+        </div>
+      </div>
 
-    <div class='input-block'>
-      <%= f.label :introduction, '商品説明', class: "mx-sm-3" %>
-      <%= f.text_area :introduction, rows: 5,placeholder: "ここに説明文を記述します", class: "col-sm-8" %>
-    </div>
+      <div class="form-group row">
+        <%= f.label :name, '商品名', class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6">
+          <%= f.text_field :name, placeholder: "商品名", class: "form-control" %>
+        </div>
+      </div>
 
-    <div class='input-block'>
-      <%= f.label :genre, 'ジャンル', class: "mx-sm-3" %>
-      <%= f.collection_select :genre_id, @genres, :id, :name, { prompt: "選択してください" }, class: "col-sm-8" %>
-    </div>
+      <div class="form-group row">
+        <%= f.label :introduction, '商品説明', class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6" rows="3" >
+          <%= f.text_field :introduction, placeholder: "商品説明", class: "form-control"%>
+        </div>
+      </div>
 
-    <div class='input-block'>
-      <%= f.label :price, '税抜価格', class: "mx-sm-3" %>
-      <%= f.text_field :price, placeholder: "1000", class: "col-sm-8" %>円
-    </div>
+      <div class="form-group row">
+        <%= f.label :genre, 'ジャンル', class: "col-sm-2 offset-sm-1 col-form-label" %>
+        <div class="col-sm-6">
+          <%= f.collection_select :genre_id, @genres, :id, :name, { prompt: "選択してください" }, class: "form-control" %>
+        </div>
+      </div>
 
-    <div class='input-block'>
-      <%= f.label :name, '販売ステータタス', class: "mx-sm-3" %>
-    　<%= f.radio_button :sale_status, true %>
-      <%= f.label :sale_status, '販売中', value: true %>
-      <%= f.radio_button :sale_status, false %>
-      <%= f.label :sale_status, '販売停止中', value: f %>
+      <div class="form-group row">
+        <%= f.label :price, "税抜価格", class:"col-sm-2 offset-sm-1 col-form-label"%>
+        <div class="col-sm-6">
+          <%= f.text_field :price, placeholder: "税抜価格", class: "form-control" %> <span>円</span>
+        </div>
+      </div>
+
+      <fieldset class="form-group">
+    <div class="row">
+      <legend class="col-form-label col-sm-2 offset-sm-1 pt-0">販売ステータス</legend>
+      <div class="col-sm-6">
+        <div class="form-check form-check-inline">
+          <%= f.radio_button :sale_status, true, class:'form-check-input' %><label　class="form-check-label">販売中</label>
+        </div>
+        <div class="form-check form-check-inline">
+    　　　　  <%= f.radio_button :sale_status, false, class:'form-check-input' %><label　class="form-check-label">販売停止中</label>
+        </div>
+      </div>
     </div>
-    <%= f.submit '新規登録', class: "btn btn-success col-xs-7" %>
-  <% end %>
- </div>
+  </fieldset>
+
+      <%= f.submit '新規登録', class: "btn btn-success col-xs-7 mx-auto d-block" %>
+    <% end %>
+ <!--</div>-->
 </div>
 

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,38 +1,55 @@
-<h5 class= "toptext text-center">商品</h5>
+
 <div class="container">
+  <h5 class= "toptext text-center">商品</h5>
   <div class="row">
     <div class="col-lg-3">
-      <%= attachment_image_tag @item, :image, :fill, 300, 300, format: 'jpeg', fallback: "no_image.jpg", size: "200x200" %><br>
+      <%= attachment_image_tag @item, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg", size: "200x150" %><br>
     </div>
     <div class="col-lg-7">
-      <table class="">
-        <tr>
-          <td>商品名</td> 
-          <td><%= @item.name %></td> 
-        </tr>
-         <tr>
-          <td>商品説明</td> 
-          <td><%= @item.introduction %></td> 
-        </tr>
-        <tr>
-          <td>ジャンル</td> 
-          <td><%= @item.genre.name%></td> 
-        </tr>
-        <tr>
-          <td>税込価格<br>（税抜き価格）</td> 
-          <td><%= @item.price %></td> 
-        </tr>
-        <tr>
-          <td>販売ステータス</td> 
-          <td>   <% if @item.sale_status %>
-            <span>販売中</span>
-            <% else %>
-            <span>販売停止中</span>
-            <% end %>
-          </td> 
-        </tr>
-      </table>
-      <%= link_to "編集する", edit_admin_item_path(@item.id), method: :get, class: "btn btn-success"%>
+
+	  <div class="row form-group">
+　    <legend class="col-sm-3 col-form-label">商品名</legend>
+      <div class="col-sm-3">
+        <legend class="form-control-plaintext"><%= @item.name %></legend>
+      </div>
+    </div>
+
+    <div class="row form-group">
+　    <legend class="col-sm-3 col-form-label">商品説明</legend>
+      <div class="col-sm-3">
+        <legend class="form-control-plaintext"><%= @item.introduction %></legend>
+      </div>
+    </div>
+
+    <div class="row form-group">
+　    <legend class="col-sm-3 col-form-label">ジャンル</legend>
+      <div class="col-sm-3">
+        <legend class="form-control-plaintext"><%= @item.genre.name%></legend>
+      </div>
+    </div>
+
+    <div class="row form-group">
+　    <legend class="col-sm-3 col-form-label">税込価格</legend>
+      <div class="col-sm-3">
+        <legend class="form-control-plaintext"><%= @item.price %></legend>
+      </div>
+    </div>
+
+    <div class="row form-group">
+　    <legend class="col-sm-3 col-form-label">販売ステータス</legend>
+      <div class="col-sm-3">
+        <legend class="form-control-plaintext">
+        	<% if @item.sale_status %>
+            <span class="text-success">販売中</span>
+          <% else %>
+            <span class="text-muted">販売停止中</span>
+           <% end %>
+        </legend>
+      </div>
+    </div>
+
+      <%= link_to "編集する", edit_admin_item_path(@item.id), method: :get, class: "btn btn-success col-sm-3 offset-sm-2"%>
     </div>
  </div>
 </div>
+

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -16,11 +16,10 @@
     <div class="row">
      <div class="flex-container">
       <% @items.each do |item|%>
-      <div class="flex-item"><%= attachment_image_tag(item, :image, :fill, 200, 200, format: 'jpeg', fallback: "no_image.jpg", size: "200x200") %></div>
-      <div class="flex-item"><%= item.name %></div>
-      <div class="flex-item"><%= item.price %></div>
-
-   <% end %>
+       <div class="flex-item"><%= attachment_image_tag(item, :image, :fill, 200, 200, format: 'jpeg', fallback: "no_image.jpg", size: "200x200") %></div>
+       <div class="flex-item"><%= item.name %></div>
+       <div class="flex-item"><%= item.price %></div>
+   　　<% end %>
    </div>
    </div>
    <div class="button">


### PR DESCRIPTION
# 管理者側のレイアウトを整えています
主に会員と商品のviewをと整えてあります。基本的にはワイヤーフレームを参考にしレイアウトしてありますが、以下未完成の部分です。
## 商品
- 一覧におけるページング
- 新規、編集における説明欄の拡張（挫折）、円表記のはみ出し（挫折）
- 税込計算（忘れてた）
## 会員
- ページ送りボタンの位置
- 会員一覧の編集ボタンは削除し名前から詳細ページに飛べるようになっています
- 詳細ページだけテーブルタグでレイアウトしてあるので他のと若干違います（こっちのが楽だけど融通は聞かない）。

ジャンルテーブルは先日より変化していません。
商品の編集が上手く出来ない現象は解決してあります。
見出しはレイアウトよく解らん

特になければ上記の修正とジャンルテーブルのレイアウト、顧客側のレイアウトを変更しようと考えていますので変更点あればスラックまでお願いします。
